### PR TITLE
Fix Uno serial init boot up issue

### DIFF
--- a/brewpi.py
+++ b/brewpi.py
@@ -156,7 +156,8 @@ except serial.SerialException, e:
 
 print >> sys.stderr, (time.strftime("%b %d %Y %H:%M:%S   ") +
 	"Notification: Script started for beer '" + config['beerName']) + "'"
-
+# wait for 10 seconds to allow an Uno to reboot (in case an Uno is being used)
+time.sleep(10)
 # read settings from Arduino
 ser.flush()
 ser.write('s')


### PR DESCRIPTION
When the Uno initializes the serial port it automatically resets.  A delay is required so that it has enough time to bootload before trying to communicate on the port.  I have added a 10 second delay.
