### PR TITLE
Update multiple Arduino support for defaults.cfg

### DIFF
--- a/brewpi.py
+++ b/brewpi.py
@@ -82,18 +82,23 @@ lcdText = ['Script starting up', ' ', ' ', ' ']
 
 # Read in command line arguments
 if len(sys.argv) < 2:
-	print >> sys.stderr, 'Using default config path ./settings/config.cfg, to override use : %s <config file full path>' % sys.argv[0]
-	configFile = './settings/config.cfg'
+	print >> sys.stderr, 'Using default base directory ./, to override use:  %s <base directory full path>' % sys.argv[0]
+	basePath = './'
 else:
-	configFile = sys.argv[1]
+	basePath = sys.argv[1]
 
-if not os.path.exists(configFile):
-	sys.exit('ERROR: Config file "%s" was not found!' % configFile)
+defaultConfigFile = basePath + 'settings/defaults.cfg'
+userConfigFile = basePath + 'settings/config.cfg'
+
+if not os.path.exists(defaultConfigFile):
+	sys.exit('ERROR: Config file "%s" was not found!' % defaultConfigFile)
+if not os.path.exists(userConfigFile):
+	sys.exit('ERROR: Config file "%s" was not found!' % userConfigFile)
 
 
 # global variables, will be initialized by startBeer()
-defaultConfig = ConfigObj('./settings/defaults.cfg')
-userConfig = ConfigObj(configFile)
+defaultConfig = ConfigObj(defaultConfigFile)
+userConfig = ConfigObj(userConfigFile)
 config = defaultConfig
 config.merge(userConfig)
 

--- a/programArduinoFirstTime.py
+++ b/programArduinoFirstTime.py
@@ -22,12 +22,23 @@ import programArduino as programmer
 
 # Read in command line arguments
 if len(sys.argv) < 2:
-	sys.exit('Usage: %s <config file full path>' % sys.argv[0])
-if not os.path.exists(sys.argv[1]):
-	sys.exit('ERROR: Config file "%s" was not found!' % sys.argv[1])
+        print >> sys.stderr, 'Using default base directory ./, to override use:  %s <base directory full path>' % sys.argv[0]
+        basePath = './'
+else:
+        basePath = sys.argv[1]
 
-configFile = sys.argv[1]
-config = ConfigObj(configFile)
+defaultConfigFile = basePath + 'settings/defaults.cfg'
+userConfigFile = basePath + 'settings/config.cfg'
+
+if not os.path.exists(defaultConfigFile):
+        sys.exit('ERROR: Config file "%s" was not found!' % defaultConfigFile)
+if not os.path.exists(userConfigFile):
+        sys.exit('ERROR: Config file "%s" was not found!' % userConfigFile)
+
+defaultConfig = ConfigObj(defaultConfigFile)
+userConfig = ConfigObj(userConfigFile)
+config = defaultConfig
+config.merge(userConfig)
 
 hexFile = config['wwwPath'] + 'uploads/brewpi_avr.hex'
 boardType = config['boardType']


### PR DESCRIPTION
These changes switch from passing in the the path to config.cfg, to passing in the base path of the BrewPi instance as an argument to several of the scripts to allow for handling of defaults.cfg in multiple Arduino setups.  I also added processing of defaults.cfg to check-running.sh and programArduinoFirstTime.py.
