### PR TITLE
Prompt only for brewpi entry in cron

### DIFF
--- a/install/updateCron.sh
+++ b/install/updateCron.sh
@@ -29,39 +29,40 @@ echo -e "\n***** Updating cron for the brewpi user... *****\n"
 
 sudo crontab -u brewpi -l > /tmp/oldcron
 if [ -s /tmp/oldcron ]; then
-   > /tmp/newcron||die
-   firstLine=true
-   while read line
-   do
-       case "$line" in
-           \#*) # just copy commented lines
-           echo "$line" >> /tmp/newcron;
-           continue ;;
-           *)
-           if ${firstLine} ; then
-               echo -e "You have some entries in the brewpi user's crontab."
-               echo -e "The cron job to start/restart brewpi has been moved to cron.d"
-               echo -e "This means the lines for brewpi in the crontab are not needed anymore."
-               echo -e "A menu will follow to ask you to keep or comment out each line. Most users will want to answer 'yes'"
-               echo -e "Please choose what you want to do with the following entries in the crontab:\n"
-               firstLine=false
-           fi
-           echo "crontab line: $line"
-           read -p "Do you want to comment out this line? [Y/n]: " yn </dev/tty
-           case "$yn" in
-               y | Y | yes | YES| Yes ) echo "Commenting line"; echo "# $line" >> /tmp/newcron;;
-               n | N | no | NO | No ) echo -e "Keeping original line\n"; echo "$line" >> /tmp/newcron;;
-               * ) echo "No valid choice received, assuming yes..."; echo "Commenting line"; echo "# $line" >> /tmp/newcron;;
-           esac
-       esac
-   done < /tmp/oldcron
-   sudo crontab -u brewpi /tmp/newcron||die
-   rm /tmp/newcron||warn
-   if ! ${firstLine}; then
-       echo -e "Updated crontab to:"
-       sudo crontab -u brewpi -l||die
-       echo -e "Finished updating crontab"
-   fi
+  if sudo grep -q "brewpi.py" /tmp/oldcron; then
+     > /tmp/newcron||die
+     firstLine=true
+     while read line
+     do
+       if [[ "$line" == *brewpi.py* ]]; then
+         case "$line" in
+             \#*) # just copy commented lines
+             echo "$line" >> /tmp/newcron;
+             continue ;;
+             *)
+             echo -e "It looks like you have an old brewpi entry in your crontab."
+             echo -e "The cron job to start/restart brewpi has been moved to cron.d"
+             echo -e "This means the lines for brewpi in your crontab are not needed anymore."
+             echo -e "Nearly all users will want to comment out this line\n"
+             firstLine=false
+             echo "crontab line: $line"
+             read -p "Do you want to comment out this line? [Y/n]: " yn </dev/tty
+             case "$yn" in
+                 y | Y | yes | YES| Yes ) echo "Commenting line"; echo "# $line" >> /tmp/newcron;;
+                 n | N | no | NO | No ) echo -e "Keeping original line\n"; echo "$line" >> /tmp/newcron;;
+                 * ) echo "No valid choice received, assuming yes..."; echo "Commenting line"; echo "# $line" >> /tmp/newcron;;
+             esac
+         esac
+       fi
+     done < /tmp/oldcron
+     sudo crontab -u brewpi /tmp/newcron||die
+     rm /tmp/newcron||warn
+     if ! ${firstLine}; then
+         echo -e "Updated crontab to:"
+         sudo crontab -u brewpi -l||die
+         echo -e "Finished updating crontab"
+     fi
+  fi
 fi
 rm /tmp/oldcron||warn
 


### PR DESCRIPTION
This will only ask the user if they want to comment out the brewpi.py cron entry. We shouldn't give the user the option to comment out stuff we didn't do
