### PR TITLE
Wifi enabler

### DIFF
--- a/utils/wifiChecker.sh
+++ b/utils/wifiChecker.sh
@@ -42,6 +42,13 @@ fi
 
 fails=0
 gateway=$(/sbin/ip route | awk '/default/ { print $3 }')
+### Sometimes network is so hosed, gateway IP is missing from ip route
+if [ -z $gateway ]; then
+    echo "BrewPi: wifiChecker: Cannot find gateway IP. Restarting wlan0 interface..." 1>&2
+    /sbin/ifdown wlan0
+    /sbin/ifup wlan0
+    exit 0
+fi
 
 while [ $fails -lt $MAX_FAILURES ]; do
 ### Try pinging, and if host is up, exit


### PR DESCRIPTION
This is a utility that periodically (via brewpi cron.d file) checks to see if the wifi connection is still up by checking for a default route and pinging the router. If this fails, it will attempt to restart the wlan0 interface, saving the user from having to restart the Pi manually (or connect monitor/keyboard, etc)
