### PR TITLE
DIY shields now properly detected.

### DIFF
--- a/brewpiVersion.py
+++ b/brewpiVersion.py
@@ -55,10 +55,11 @@ class AvrInfo:
     log = "l"
     commit = "c"
 
+    shield_diy = "diy"
     shield_revA = "revA"
     shield_revC = "revC"
 
-    shields = {1: shield_revA, 2: shield_revC}
+    shields = {0: shield_diy, 1: shield_revA, 2: shield_revC}
 
     board_leonardo = "leonardo"
     board_standard = "standard"


### PR DESCRIPTION
Version detection code wasn't looking for the values being sent by the DIY shield. This tiny patch adds them.
