### PR TITLE
Fix encoding of RoomTemp and State as number instead of string

### DIFF
--- a/brewpiJson.py
+++ b/brewpiJson.py
@@ -93,12 +93,12 @@ def addRow(jsonFileName, row):
 	if row['RoomTemp'] is None:
 		jsonFile.write("null,")
 	else:
-		jsonFile.write("{\"v\":\"" + str(row['RoomTemp']) + "\"},")
+		jsonFile.write("{\"v\":" + str(row['RoomTemp']) + "},")
 
 	if row['State'] is None:
 		jsonFile.write("null")
 	else:
-		jsonFile.write("{\"v\":\"" + str(row['State']) + "\"}")
+		jsonFile.write("{\"v\":" + str(row['State']) + "}")
 
 	# rewrite end of json file
 	jsonFile.write("]}]}")


### PR DESCRIPTION
The current script generates the RoomTemp and State as strings and not numbers. This can cause problems when using the data for graphing.

Example:
```
{"c":[{"v":"Date(2014,4,4,0,0,50)"},{"v":20.19},null,null,{"v":20.0},null,null,{"v":"20.13"},{"v":"0"}]},
{"c":[{"v":"Date(2014,4,4,0,0,51)"},{"v":20.19},null,null,{"v":20.0},null,null,{"v":"20.13"},{"v":"0"}]},
{"c":[{"v":"Date(2014,4,4,0,2,51)"},{"v":20.19},null,null,{"v":20.0},null,null,{"v":"20.13"},{"v":"0"}]},
```
Note that the first two number values (BeerTemp and FridgeTemp) are without quotes while RoomTemp and State do have quotes.