### PR TITLE
Update BrewPi to search for Arduino tty path

### DIFF
--- a/BrewPiProcess.py
+++ b/BrewPiProcess.py
@@ -125,8 +125,10 @@ class BrewPiProcesses():
         if cfg:
             cfg = cfg[0]  # add full path to config file
         bp.cfg = util.readCfgWithDefaults(cfg)
-
-        bp.port = bp.cfg['port']
+        try:
+            bp.port = bp.cfg['port']
+        except KeyError:
+            bp.port = util.findArduino()
         bp.sock = BrewPiSocket.BrewPiSocket(bp.cfg)
         return bp
 

--- a/brewpi.py
+++ b/brewpi.py
@@ -321,7 +321,10 @@ def resumeLogging():
     else:
         return {'status': 1, 'statusMessage': "Logging was not paused."}
 
-port = config['port']
+try:
+    port = config['port']
+except KeyError:
+    port = util.findArduino()
 ser, conn = util.setupSerial(config)
 
 logMessage("Notification: Script started for beer '" + urllib.unquote(config['beerName']) + "'")

--- a/programArduino.py
+++ b/programArduino.py
@@ -45,20 +45,13 @@ def loadBoardsFile(arduinohome):
     return open(arduinohome + 'hardware/arduino/boards.txt', 'rb').readlines()
 
 
-def openSerial(port, altport, baud, timeoutVal):
+def openSerial(port, baud, timeoutVal):
     # open serial port
     try:
         ser = serial.Serial(port, baud, timeout=timeoutVal)
         return [ser, port]
     except serial.SerialException as e:
-        printStdErr("Error opening serial port: %s. Trying alternative serial port %s." % (str(e), altport))
-        try:
-            ser = serial.Serial(altport, baud, timeout=timeoutVal)
-            return [ser, altport]
-        except serial.SerialException as e:
-            printStdErr("Error opening alternative serial port: %s. Script will exit." % str(e))
-            return [None, None]
-
+        printStdErr("Error opening serial port: %s. Please set port in config.cfg and try again." % (str(e)))
 
 def programArduino(config, boardType, hexFile, restoreWhat):
     printStdErr("****    Arduino Program script started    ****")
@@ -87,7 +80,8 @@ def programArduino(config, boardType, hexFile, restoreWhat):
     printStdErr("Devices will " + ("" if restoreDevices else "not ") + "be restored" +
                 (" if possible" if restoreSettings else ""))
 
-    ser, port = openSerial(config['port'], config['altport'], 57600, 0.2)
+    port = findArduino()
+    ser, port = openSerial(port, 57600, 0.2)
     if ser is None:
         printStdErr("Could not open serial port. Programming aborted.")
         return 0
@@ -195,7 +189,7 @@ def programArduino(config, boardType, hexFile, restoreWhat):
     ser.close()
     del ser  # Arduino won't reset when serial port is not completely removed
     if boardType == 'leonardo':
-        ser, port = openSerial(config['port'], config['altport'], 1200, 0.2)
+        ser, port = openSerial(port, 1200, 0.2)
         if ser is None:
             printStdErr("Could not open serial port at 1200 baud to reset Arduino Leonardo")
             return 0
@@ -218,7 +212,7 @@ def programArduino(config, boardType, hexFile, restoreWhat):
         countDown -= 1
         printStdErr("Back up in " + str(countDown) + "...")
 
-    ser, port = openSerial(config['port'], config['altport'], 57600, 0.2)
+    ser, port = openSerial(port, 57600, 0.2)
     if ser is None:
         printStdErr("Error opening serial port after programming. Program script will exit. Settings are not restored.")
         return 0

--- a/settings/defaults.cfg
+++ b/settings/defaults.cfg
@@ -3,8 +3,6 @@
 
 scriptPath = /home/brewpi/
 wwwPath = /var/www/
-port = /dev/ttyACM0
-altport = /dev/ttyACM1
 boardType = leonardo
 beerName = My First BrewPi Run
 interval = 120.0


### PR DESCRIPTION
Issue #41 

Searches /dev for arduino
Removes 'port' from defaults.cfg, so that not setting it in the main config doesn't override the search
Still allows 'port' to be set by the user in the main .cfg file, to override the search path
Removes altport from config & default config as it is no longer needed
