### PR TITLE
Change serial to be streamable/non-blocking

### DIFF
--- a/brewpiVersion.py
+++ b/brewpiVersion.py
@@ -23,6 +23,8 @@ def getVersionFromSerial(ser):
     retries = 0
     requestVersion = True
     startTime = time.time()
+    oldTimeOut = ser.timeout;
+    ser.setTimeout(1);
     ser.write('n')  # request version info
     while requestVersion:
         retry = True
@@ -44,6 +46,7 @@ def getVersionFromSerial(ser):
             retries += 1
             if retries > 15:
                 break
+    ser.setTimeout(oldTimeOut); # restore previous serial timeout value
     return version
 
 

--- a/programArduino.py
+++ b/programArduino.py
@@ -159,12 +159,11 @@ def openSerial(port, altport, baud, timeoutVal):
         return [ser, port]
     except serial.SerialException as e:
         if altport:
-            printStdErr("Error opening serial port: %s. Trying alternative serial port %s." % (str(e), altport))
             try:
                 ser = serial.Serial(altport, baud, timeout=timeoutVal)
                 return [ser, altport]
             except serial.SerialException as e:
-                printStdErr("Error opening alternative serial port: %s. Script will exit." % str(e))
+                pass
         return [None, None]
 
 


### PR DESCRIPTION
This pull request changes how serial is read: it removes the time out and makes serial non-blocking.
This improves responsiveness of the script a lot and prevents serial timeout errors when the controller takes longer than expected to respond.

Data from serial is now read into a buffer and lineFromSerial() checks whether a full line is available, without waiting.

To fix the version read from the controller (which does want to wait for an answer), a timeout has to be applied temporarily.
This could be later refactored by moving the serial buffer to a class that is used by both files and giving lineFromSerial() an optional timeout/wait argument