### PR TITLE
bugfixes in BrewPiProcess and BrewPiSocket

### DIFF
--- a/BrewPiProcess.py
+++ b/BrewPiProcess.py
@@ -33,7 +33,7 @@ try:
 
 
 except ImportError:
-    print "BrewPi requires psutil to run, please install it with 'sudo apt-get install python-psutil"
+    print "BrewPi requires psutil to run, please install it via pip: 'sudo pip install psutil --upgrade"
     sys.exit(1)
 
 import BrewPiSocket
@@ -82,7 +82,7 @@ class BrewPiProcess:
         try:
             process.kill()
             print "SIGKILL sent to BrewPi instance with pid %d!" % self.pid
-        except psutil.error.AccessDenied:
+        except psutil.AccessDenied:
             print >> sys.stderr, "Cannot kill process %d, you need root permission to do that." % self.pid
             print >> sys.stderr, "Is the process running under the same user?"
 
@@ -134,8 +134,10 @@ class BrewPiProcesses():
         cfg = [s for s in process.cmdline() if '.cfg' in s]  # get config file argument
         if cfg:
             cfg = cfg[0]  # add full path to config file
+        else:
+            # use default config file location
+            cfg = util.scriptPath() + "/settings/config.cfg"
         bp.cfg = util.readCfgWithDefaults(cfg)
-
         bp.port = bp.cfg['port']
         bp.sock = BrewPiSocket.BrewPiSocket(bp.cfg)
         return bp

--- a/BrewPiSocket.py
+++ b/BrewPiSocket.py
@@ -39,9 +39,10 @@ class BrewPiSocket:
 		self.sock = 0
 
 		isWindows = sys.platform.startswith('win')
-		useInternetSocket = bool(cfg.get('useInternetSocket', isWindows))
+		useInternetSocket = bool(cfg.get('useInetSocket', isWindows))
 		if useInternetSocket:
-			self.port = cfg.get('socketPort', 6332)
+			self.port = int(cfg.get('socketPort', 6332))
+			self.host = cfg.get('socketHost', "localhost")
 			self.type = 'i'
 		else:
 			self.file = util.addSlash(cfg['scriptPath']) + 'BEERSOCKET'
@@ -86,7 +87,8 @@ class BrewPiSocket:
 				sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 				sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 				sock.connect(self.file)
-		except socket.error:
+		except socket.error as e:
+			print e
 			sock = False
 		finally:
 			return sock


### PR DESCRIPTION
when using an internet socket, sending quit messages via --quit would fail. Port number was not read as integer. useInternetSocket was used as key instead of useInetSocket, exception name changed in new version of psutil and it the class did not read the default config.