### PR TITLE
replace / with _ in beer names

### DIFF
--- a/brewpi.py
+++ b/brewpi.py
@@ -562,7 +562,7 @@ while run:
                 logMessage("Notification: Interval changed to " +
                            str(newInterval) + " seconds")
         elif messageType == "startNewBrew":  # new beer name
-            newName = value
+            newName = value.replace("/","_") # name is used as part of file path, *nix can't handle /s in filenames
             result = startNewBrew(newName)
             conn.send(json.dumps(result))
         elif messageType == "pauseLogging":


### PR DESCRIPTION
Issue #29
We use the beer name as part of the file path for saving data... no problems there if we use MyBeer as a name,
the path is /path/to/MyBeer . However, if we use My/Beer as the name, the filepath becomes /path/to/My/Beer and
breaks everything. We simply replace / with _ to avoid this problem. Note- Windows has a TON of restricted chars
and COMBOS of chars that are restricted, but not addressed in this patch.