### PR TITLE
catch AccessDenied error when running script from the command line.

### DIFF
--- a/BrewPiProcess.py
+++ b/BrewPiProcess.py
@@ -115,7 +115,14 @@ class BrewPiProcesses():
         Returns: list of BrewPiProcess objects
         """
         bpList = []
-        matching = [p for p in psutil.process_iter() if any('python' in p.name() and 'brewpi.py'in s for s in p.cmdline())]
+        matching = []
+
+        # some OS's (OS X) do not allow processes to read info from other processes. 
+        try:
+            matching = [p for p in psutil.process_iter() if any('python' in p.name() and 'brewpi.py'in s for s in p.cmdline())]
+        except psutil.AccessDenied:
+            pass
+
         for p in matching:
             bp = self.parseProcess(p)
             bpList.append(bp)


### PR DESCRIPTION
OS X does not allow processes to read info about other processes (apparently.)

Since the process info isn't needed when developing on OS X, this fix catches the error and returns an empty list for the list of processes.