### PR TITLE
Serial and programming fix

### DIFF
--- a/brewpi.py
+++ b/brewpi.py
@@ -357,6 +357,7 @@ time.sleep(float(config.get('startupDelay', 10)))
 
 ser.flush()
 
+logMessage("Checking software version on controller... ")
 hwVersion = brewpiVersion.getVersionFromSerial(ser)
 if hwVersion is None:
     logMessage("Warning: Cannot receive version number from Arduino. " +
@@ -638,7 +639,7 @@ while run:
                     raise socket.timeout  # go to serial communication to update Arduino
         elif messageType == "programArduino":
             ser.close()  # close serial port before programming
-            del ser  # Arduino won't reset when serial port is not completely removed
+            # del ser  # Arduino won't reset when serial port is not completely removed
             try:
                 programParameters = json.loads(value)
                 hexFile = programParameters['fileName']

--- a/brewpiVersion.py
+++ b/brewpiVersion.py
@@ -26,26 +26,26 @@ def getVersionFromSerial(ser):
     oldTimeOut = ser.timeout;
     ser.setTimeout(1);
     ser.write('n')  # request version info
-    while requestVersion:
+    while True:
         retry = True
         line = ser.readline()
         if line:
             if line[0] == 'N':
                 data = line.strip('\n')[2:]
                 version = AvrInfo(data)
-                requestVersion = False
                 retry = False
-                break
-            if time.time() - startTime > ser.timeout:
+            if time.time() - startTime >= ser.timeout:
                 # have read entire buffer, now just reading data as it comes in. Break to prevent an endless loop.
-                break
+                retry = False
 
         if retry:
             ser.write('n')  # request version info
-            time.sleep(1)
+            # time.sleep(1) delay not needed because of blocking (timeout) readline
             retries += 1
-            if retries > 15:
+            if retries > 10:
                 break
+        else:
+            break
     ser.setTimeout(oldTimeOut); # restore previous serial timeout value
     return version
 


### PR DESCRIPTION
This PR fixes programming for the Arduino and it reduces serial port traffic for the main script.

- While debugging the Serial issues I discovered that new settings and new LCD text were requested more than once per second. Now both updates are on a timer.
- ser.name is used instead of port because if altport is used, using port results in the wrong name
- deleting the serial port (which is needed to the leo to get into bootloader) has been moved to a leonardo_reset function
- Better error reporting and fixed some errors in format strings

Let's merge this into master asap because programming is broken for the Arduino.