### PR TITLE
point to correct fixPermissions.sh path

### DIFF
--- a/brewpi_util.py
+++ b/brewpi_util.py
@@ -84,7 +84,7 @@ def config_set(config_file, setting_name, value):
             e.errno, config_file, e.strerror)
         )
         log_message("Your permissions may not be set correctly. To fix this, "
-                    "run 'sudo sh /home/brewpi/fixPermissions.sh'")
+                    "run 'sudo sh /home/brewpi/utils/fixPermissions.sh'")
     return read_cfg_with_defaults(config_file)  # return updated ConfigObj
 
 


### PR DESCRIPTION
I was having some issues earlier due to permissions, and I was getting the message "Probably your permissions are not set correctly. To fix this, run 'sudo sh /home/brewpi/fixPermissions.sh'" in my logs. This path wasn't correct so this pull request should fix it.