### PR TITLE
generic serial open to support socket devices (for wifi)

### DIFF
--- a/BrewPiUtil.py
+++ b/BrewPiUtil.py
@@ -132,7 +132,7 @@ def setupSerial(config, baud_rate=57600, time_out=0.1):
             else:
                 port = portSetting
             try:
-                ser = serial.Serial(port, baudrate=baud_rate, timeout=time_out, write_timeout=0)
+                ser = serial.serial_for_url(port, baudrate=baud_rate, timeout=time_out, write_timeout=0)
                 if ser:
                     break
             except (IOError, OSError, serial.SerialException) as e:

--- a/backgroundserial.py
+++ b/backgroundserial.py
@@ -94,7 +94,6 @@ class BackGroundSerial():
                     line_from_buffer = self.__get_line_from_buffer()
                     if line_from_buffer:
                         self.queue.put(line_from_buffer)
-                        print(line_from_buffer)
                     else:
                         break
 


### PR DESCRIPTION
Tiny patch so uri (e.g. socket://127.0.0.1:9876) can be used when opening the serial port. Keeps compatibility with device path (e.g. /dev/ttyACM0)

Cheers,
Guillaume