### PR TITLE
Update packages for RASPBERRY PI 3 MODEL B

### DIFF
--- a/utils/installDependencies.sh
+++ b/utils/installDependencies.sh
@@ -46,7 +46,7 @@ if [ $(($nowTime - $lastUpdate)) -gt 604800 ] ; then
     sudo apt-get update||die
 fi
 
-sudo apt-get install -y apache2 libapache2-mod-php5 php5-cli php5-common php5-cgi php5 git-core build-essential python-dev python-pip git-core || die
+sudo apt-get install -y apache2 libapache2-mod-php7.0 php7.0-cli php7.0-common php7.0-cgi php7.0-mbstring php7.0 git build-essential python-dev python-pip || die
 
 echo -e "\n***** Installing/updating required python packages via pip... *****\n"
 


### PR DESCRIPTION
RASPBERRY PI 3 MODEL B has php7.0.  Could probably add logic to `apt-cache search php7.0` first or `apt-cache search php5`